### PR TITLE
Build: Add and use Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,10 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Build
-      run: |
-        npm install
-        npm run build -- --prod
+      run: make
       env:
         CI: true
     - name: Test
-      run: npm test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+      run: make test
       env:
         CI: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: all build clean deploy
+
+all: build
+
+build:
+	npm install ;\
+        npm run build -- --prod
+
+test:
+	npm test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+
+clean:
+	ng build --delete-output-path
+
+deploy: build
+	gcloud app deploy .
+


### PR DESCRIPTION
Hide the npm/ng incantations behind a simple Makefile.
And use this in the GitHub Actions CI definition instead of repeating
those incantations.