### PR TITLE
UserHistorySectionsComponent: Really update progress bars after an an…

### DIFF
--- a/src/app/data-structure/user-history-sections.ts
+++ b/src/app/data-structure/user-history-sections.ts
@@ -41,6 +41,22 @@ export class UserHistorySections {
     return this.statsMap.get(sectionId);
   }
 
+  public setUserStatsForSection(sectionId: string, userStats: UserStats) {
+    if (!this.statsMap) {
+      return undefined;
+    }
+
+    // Update in stats.
+    for (var i = 0; i < this.stats.length; i++) {
+      if( this.stats[i].sectionId == sectionId){
+        this.stats[i] = userStats;
+      }
+    }
+
+    // Update in the map.
+    this.statsMap.set(sectionId, userStats);
+  }
+
   public hasUser(): boolean {
     if (!this.loginInfo) {
       return false;

--- a/src/app/user-history-sections.component.ts
+++ b/src/app/user-history-sections.component.ts
@@ -147,5 +147,9 @@ export class UserHistorySectionsComponent extends BaseComponent implements OnIni
     }
 
     stats.updateProblemQuestion(data.question, data.result);
+
+    // Properly update the UserHistorySections,
+    // so it will be re-rendered.
+    this.userHistorySections.setUserStatsForSection(data.question.sectionId, stats)
   }
 }


### PR DESCRIPTION
…swer

Instead of only showing the new values after a page refresh.

We were changing statsMap, but not stats, which was what was actually
used by the HTML.