### PR TITLE
app-routing: Use anchorScrolling and scrollPositionRestoration

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -24,6 +24,11 @@ const routes: Routes = [
 
 @NgModule({
   exports: [ RouterModule ],
-  imports: [ RouterModule.forRoot(routes) ],
+  imports: [
+    RouterModule.forRoot(routes, {
+      anchorScrolling: "enabled",
+      scrollPositionRestoration: "enabled",
+    }),
+  ],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
For instance, to make the browser scroll up when we go to a "page" via
an internal link. Otherwise, we can be left at the (often empty) bottom
of a page, requiring the user to scroll up to see the actual content.